### PR TITLE
Use `he` for robust HTML entity encoding/decoding

### DIFF
--- a/build/script.js
+++ b/build/script.js
@@ -150,7 +150,7 @@ function getSelectedIcons() {
  * @returns {Function}
  */
 function getGlyphParser( root ) {
-    var ent = require( "ent" );
+    var he = require( "he" );
     var SvgPath = require( "svgpath" );
 
     // Fontello uses ascent = 850, WHHGlyphs uses 819. This makes the font look disaligned.
@@ -199,7 +199,7 @@ function getGlyphParser( root ) {
         unicodeAttr = glyph.unicode;
         if ( unicodeAttr ) {
             // We'll need to decode HTML entities
-            unicodeAttr = ent.decode( unicodeAttr );
+            unicodeAttr = he.decode( unicodeAttr );
         }
 
         // Uses glyph-name, unless it's so stupid.

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
     "dependencies": {
         "adm-zip": "0.4.4",
         "commander": "2.2.0",
-        "ent": "0.1.0",
+        "he": "0.5.0",
         "restler": "3.2.0",
         "strip-json-comments": "0.1.1",
         "svgpath": "1.0.4",
-        "xml2js": "0.4.1",
-        "wrench": "1.5.8"
+        "wrench": "1.5.8",
+        "xml2js": "0.4.1"
     },
     "bin": {
         "whhglyphs": "build/script.js",


### PR DESCRIPTION
_ent_ has [several open issues](https://github.com/substack/node-ent/issues/created_by/mathiasbynens?state=open) that are not present in [_he_](https://mths.be/he).
